### PR TITLE
Updates Maven to v3.9.15

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Maven
         uses: stCarolas/setup-maven@v5
         with:
-          maven-version: 3.9.14
+          maven-version: 3.9.15
 
       # Build normal JAR
       - name: Build with Maven

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the application within Docker
-FROM maven:3.9.14-eclipse-temurin-21 AS build
+FROM maven:3.9.15-eclipse-temurin-21 AS build
 WORKDIR /app
 COPY release-to-issue-java/pom.xml .
 COPY release-to-issue-java/src ./src


### PR DESCRIPTION
Closes #47.

Blocked by https://github.com/carlossg/docker-maven/issues/644.